### PR TITLE
Provide own .babelrc, add Radium

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "stage": 0,
+  "nonStandard": true
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "builder": "^2.0.1",
-    "builder-react-component": "0.0.3",
+    "builder-react-component": "0.0.4",
     "radium": "^0.14.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "builder": "^2.0.1",
-    "builder-react-component": "0.0.3"
+    "builder-react-component": "0.0.3",
+    "radium": "^0.14.3"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/src/components/victory-component-boilerplate.jsx
+++ b/src/components/victory-component-boilerplate.jsx
@@ -1,5 +1,7 @@
 import React from "react";
+import Radium from "radium";
 
+@Radium
 export default class VictoryComponentBoilerplate extends React.Component {
   render() {
     return <div>Edit me!</div>;


### PR DESCRIPTION
This adds a `.babelrc` until we can resolve FormidableLabs/builder-react-component#4. Since stage 0 is now being used as intended, bring back `@Radium`.

/cc @ryan-roemer @boygirl
