### PR TITLE
Upgrade builder; use correct archetype

### DIFF
--- a/.builderrc
+++ b/.builderrc
@@ -1,3 +1,3 @@
 ---
 archetypes:
-  - builder-react-component
+  - builder-victory-component

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "test": "builder run npm:test"
   },
   "dependencies": {
-    "builder": "2.1.0",
-    "builder-react-component": "0.1.0",
+    "builder": "^2.2.0",
+    "builder-victory-component": "~0.0.5",
     "radium": "^0.14.3"
   },
   "devDependencies": {
-    "builder-react-component-dev": "0.1.0",
+    "builder-victory-component-dev": "~0.0.5",
     "chai": "^3.2.0",
     "mocha": "^2.3.3",
     "react": "^0.14.0",


### PR DESCRIPTION
I missed these changes before – this fixes https://github.com/FormidableLabs/builder-victory-component/issues/14.
