### PR TITLE
Split up App and Demo to fix hot reloading

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -1,18 +1,8 @@
 /*global document:false*/
 import React from "react";
 import ReactDOM from "react-dom";
-import {VictoryComponentBoilerplate} from "../src/index";
-
-class App extends React.Component {
-  render() {
-    return (
-      <div className="demo">
-        <VictoryComponentBoilerplate />
-      </div>
-    );
-  }
-}
+import Demo from "./demo";
 
 const content = document.getElementById("content");
 
-ReactDOM.render(<App/>, content);
+ReactDOM.render(<Demo/>, content);

--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import {VictoryComponentBoilerplate} from "../src/index";
+
+class Demo extends React.Component {
+  render() {
+    return (
+      <div className="demo">
+        <VictoryComponentBoilerplate />
+      </div>
+    );
+  }
+}
+
+export default Demo;

--- a/demo/index.html
+++ b/demo/index.html
@@ -41,7 +41,6 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.15/es5-shim.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.15/es5-sham.min.js"></script>
   <![endif]-->
-  <script src="http://localhost:3000/webpack-dev-server.js"></script>
   <script src="assets/main.js"></script>
   <script>
     // Sanity-check the component loaded...

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "builder": "^2.2.0",
-    "builder-victory-component": "~0.0.5",
+    "builder-victory-component": "~0.1.2",
     "radium": "^0.14.3"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "~0.0.5",
+    "builder-victory-component-dev": "~0.1.2",
     "chai": "^3.2.0",
     "mocha": "^2.3.3",
     "react": "^0.14.0",


### PR DESCRIPTION
- Hot reload needs the rendered component to be exported from a separate module.
- Remove `webpack-dev-server` from index.html; `webpack` runs with `--inline`
  in hot mode, which removes the need for an external script.

Fixes https://github.com/FormidableLabs/victory/issues/165
